### PR TITLE
Allow compact data and name expression arguments

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,9 @@ configurations {
 configurations.shadowImpl.extendsFrom(configurations.implementation)
 
 dependencies {
+	testImplementation "org.junit.jupiter:junit-jupiter:5.11.4"
+	testRuntimeOnly "org.junit.platform:junit-platform-launcher:1.11.4"
+
 	implementation 'org.eclipse.lsp4j:org.eclipse.lsp4j:0.24.0'
 	implementation 'org.eclipse.lsp4j:org.eclipse.lsp4j.debug:0.24.0'
 	implementation 'jakarta.websocket:jakarta.websocket-api:2.2.0'
@@ -87,6 +90,10 @@ processResources {
 
 tasks.withType(JavaCompile).configureEach {
 	it.options.release = 25
+}
+
+tasks.named("test") {
+	useJUnitPlatform()
 }
 
 

--- a/src/main/kotlin/dev/mcbookshelf/sniffer/commands/ArgumentType.kt
+++ b/src/main/kotlin/dev/mcbookshelf/sniffer/commands/ArgumentType.kt
@@ -144,9 +144,13 @@ class ExprArgumentType: ArgumentType<ExprArgumentType.Companion.Experiment> {
 
     fun parseArgument(reader: StringReader): DebugData {
         reader.expect('(')
-        reader.skipWhitespace()
-        val parsedData = parseArgumentWithoutBrackets(reader)
-        reader.skipWhitespace()
+        val argumentReader = StringReader(reader.readUntil(')'))
+        argumentReader.skipWhitespace()
+        val parsedData = parseArgumentWithoutBrackets(argumentReader)
+        argumentReader.skipWhitespace()
+        if(argumentReader.canRead()){
+            throw INVALID_ARG_ERROR.createWithContext(argumentReader)
+        }
         reader.expect(')')
         return parsedData
     }
@@ -363,6 +367,7 @@ class ExprArgumentType: ArgumentType<ExprArgumentType.Companion.Experiment> {
         }
 
         private val EMPTY_EXPR_ERROR = SimpleCommandExceptionType { "Empty expression" }
+        private val INVALID_ARG_ERROR = SimpleCommandExceptionType { "Invalid expression argument" }
         private val MISSING_OP_ERROR = SimpleCommandExceptionType { "Missing operation between arguments" }
         private val MISSING_ARG_ERROR = SimpleCommandExceptionType { "Missing arguments after operation" }
         private val OPERATION_TYPE_ERROR = Dynamic3CommandExceptionType { operation, left, right -> Message { "Operation $operation is not applicable to $left and $right" }}

--- a/src/test/kotlin/dev/mcbookshelf/sniffer/commands/ExprArgumentTypeTest.kt
+++ b/src/test/kotlin/dev/mcbookshelf/sniffer/commands/ExprArgumentTypeTest.kt
@@ -1,0 +1,41 @@
+package dev.mcbookshelf.sniffer.commands
+
+import com.mojang.brigadier.StringReader
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Test
+
+class ExprArgumentTypeTest {
+
+    @Test
+    fun `data argument parses without whitespace before closing parenthesis`() {
+        assertParses("{(data storage demo:test value)}")
+    }
+
+    @Test
+    fun `data argument still parses with whitespace before closing parenthesis`() {
+        assertParses("{(data storage demo:test value )}")
+    }
+
+    @Test
+    fun `name argument parses without whitespace before closing parenthesis`() {
+        assertParses("{(name @s)}")
+    }
+
+    @Test
+    fun `name argument still parses with whitespace before closing parenthesis`() {
+        assertParses("{(name @s )}")
+    }
+
+    @Test
+    fun `score argument still parses without whitespace before closing parenthesis`() {
+        assertParses("{(score @s test)}")
+    }
+
+    private fun assertParses(expression: String) {
+        val reader = StringReader(expression)
+
+        ExprArgumentType().parse(reader)
+
+        assertFalse(reader.canRead(), "Parser did not consume the complete expression")
+    }
+}


### PR DESCRIPTION
## Summary

- parse parenthesized expression arguments with a bounded reader
- allow `data` and `name` arguments with or without trailing whitespace
- preserve the existing compact `score` syntax
- add parser-level regression tests

## Testing

- `.\gradlew.bat --no-daemon clean test build --console=plain`
- 5 tests, 0 failures

Closes #26