### PR TITLE
Improve callstack output

### DIFF
--- a/src/main/kotlin/dev/mcbookshelf/sniffer/ui/StackFormatter.kt
+++ b/src/main/kotlin/dev/mcbookshelf/sniffer/ui/StackFormatter.kt
@@ -45,14 +45,15 @@ object StackFormatter {
         boldTop: Boolean,
         highlightColor: Int = color,
     ): MutableComponent {
-        var text: MutableComponent = Component.empty()
+        var text: MutableComponent = Component.literal("\nCall stack:\n").withColor(color)
         val stacks = ScopeManager.get().debugScopes
         for ((count, stack) in stacks.withIndex()) {
             if (count >= maxStack) {
                 text.append(Component.literal("... (${stacks.size - count} more)").withColor(color))
                 break
             }
-            val t = Component.literal(stack.function)
+            val lineStr = if (stack.line >= 0) ":${stack.line + 1}" else ""
+            val t = Component.literal("${stack.function}$lineStr")
             val isTop = stacks.indexOf(stack) == 0
             t.style = t.style
                 .withBold(boldTop && isTop)


### PR DESCRIPTION
### Problem addressed

The output of the command `/breakpoint stack` could be enhanced:
- First, the line number is not displayed.
- There is no separator before (or after) the message making it hard to see where we actually are, especially when calling  `/breakpoint stack` multiple times, like in the following image.
<img width="1906" height="1023" alt="image" src="https://github.com/user-attachments/assets/7140bc73-20c4-4705-b4fe-bd7eb9ea6912" />



### Solution
Enhance the output to follow this format:
```
\n
Call stack:
datapack_name:function:line_number
...
datapack_name:function:line_number
```

Same example as above, but with the new output:
<img width="1906" height="1023" alt="image" src="https://github.com/user-attachments/assets/b360121c-ef5f-430f-baef-658b9d43dca3" />



Note in the following screenshot that it's in sync with the actual line count, even with a file containing comments and empty lines.

<img width="1906" height="1023" alt="image" src="https://github.com/user-attachments/assets/352c4351-e7a5-4215-b675-d3c7e02a8551" />
