### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Command Syntax:
 - `watch auto [true|false]`: Set whether auto reloading is enabled. Auto reloading will apply any change once the watcher detects it. Default is `false`. If value is not provided, it will tell you if the auto reloading is enabled.
 
 say start
-#breakpoint
+#!breakpoint
 $say $(msg)
 say end
 ```
@@ -213,7 +213,7 @@ say 2
 
 #test: test2
 say A
-#breakpoint
+#!breakpoint
 say B
 ```
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The debugger can be controlled directly from Minecraft using the following comma
 
 * Continue
 
-When the game is "frozen", you can use the command `/breakpoint move` to unfreeze the game and continue running.
+When the game is "frozen", you can use the command `/breakpoint continue` to unfreeze the game and continue running.
 
 * Get Macro Arguments
 

--- a/src/main/resources/assets/sniffer/lang/en_us.json
+++ b/src/main/resources/assets/sniffer/lang/en_us.json
@@ -10,7 +10,7 @@
   "sniffer.commands.breakpoint.get.fail.error": "Unexpected error while getting the value of argument: %s",
   "sniffer.commands.breakpoint.get.fail.not_macro": "Current function is not a macro",
   "sniffer.commands.breakpoint.move": "The game is now moving on",
-  "sniffer.commands.breakpoint.move.not_debugging": "Can only use `move` command in breakpoint mode",
+  "sniffer.commands.breakpoint.move.not_debugging": "Can only use `continue` command in breakpoint mode",
   "sniffer.commands.breakpoint.set": "Breakpoint has triggered",
   "sniffer.commands.breakpoint.step.fail": "Can only use `step` command in breakpoint mode",
   "sniffer.commands.jvmtimer.disable": "Timer %s is disabled",

--- a/src/main/resources/assets/sniffer/lang/fr_fr.json
+++ b/src/main/resources/assets/sniffer/lang/fr_fr.json
@@ -10,7 +10,7 @@
   "sniffer.commands.breakpoint.get.fail.error": "Erreur inattendue lors de la récupération de la valeur de l'argument : %s",
   "sniffer.commands.breakpoint.get.fail.not_macro": "La fonction actuelle n'est pas une macro",
   "sniffer.commands.breakpoint.move": "Le jeu reprend son cours",
-  "sniffer.commands.breakpoint.move.not_debugging": "La commande `move` ne peut être utilisée qu'en mode point d'arrêt",
+  "sniffer.commands.breakpoint.move.not_debugging": "La commande `continue` ne peut être utilisée qu'en mode point d'arrêt",
   "sniffer.commands.breakpoint.set": "Un point d'arrêt a été déclenché",
   "sniffer.commands.breakpoint.step.fail": "La commande `step` ne peut être utilisée qu'en mode point d'arrêt",
   "sniffer.commands.jvmtimer.disable": "Le minuteur %s est désactivé",

--- a/src/main/resources/assets/sniffer/lang/zh_cn.json
+++ b/src/main/resources/assets/sniffer/lang/zh_cn.json
@@ -10,7 +10,7 @@
   "sniffer.commands.breakpoint.get.fail.error": "获取参数的值: %s 时发生了意外错误",
   "sniffer.commands.breakpoint.get.fail.not_macro": "此函数不是宏",
   "sniffer.commands.breakpoint.move": "游戏已继续",
-  "sniffer.commands.breakpoint.move.not_debugging": "`move` 命令只能在断点时使用",
+  "sniffer.commands.breakpoint.move.not_debugging": "`continue` 命令只能在断点时使用",
   "sniffer.commands.breakpoint.set": "断点已触发",
   "sniffer.commands.breakpoint.step.fail": "`step` 命令只能在断点时使用",
   "sniffer.commands.jvmtimer.disable": "计时器 %s 已禁用",


### PR DESCRIPTION
### Problem addressed

- Some translations refer to `/breakpoint move` but the command does not exist anymore, it's `/breakpoint continue`
- The README.md is missing two `!`
### Solution

Tautological